### PR TITLE
which-key: init

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,13 +47,12 @@
     neovimStartPlugins = forAllSystems
     (
       pkgs:
-      {}
 
-      # llakaLib.collectDirectoryPackages
-      # {
-      #   inherit pkgs;
-      #   directory = ./other/startPlugins;
-      # }
+      llakaLib.collectDirectoryPackages
+      {
+        inherit pkgs;
+        directory = ./other/startPlugins;
+      }
     );
 
     # See above!

--- a/nvim/lua/lazy/which-key.lua
+++ b/nvim/lua/lazy/which-key.lua
@@ -1,0 +1,8 @@
+return {
+  "which-key.nvim",
+  after = function()
+    require("which-key").setup({
+      preset = "modern",
+    })
+  end,
+}

--- a/nvim/plugin/plugins.lua
+++ b/nvim/plugin/plugins.lua
@@ -7,12 +7,31 @@ require("ibl").setup({
 
 require("nvim-surround").setup({
   move_cursor = "sticky",
+
+  -- We disable all the default keymaps, instead choosing to access
+  -- nvim-surround through `surround-ui` (or, actually, my fork that makes
+  -- surround-ui not use hardcoded keymaps)
   keymaps = {
-    normal = "s",
-    delete = "ds",
-    change = "cs",
+    insert = false,
+    insert_line = false,
+
+    normal = false,
+
+    normal_cur = false,
+    normal_line = false,
+    normal_cur_line = false,
+
+    visual = false,
+    visual_line = false,
+
+    delete = false,
+
+    change = false,
+    change_line = false,
   },
 })
+
+require("surround-ui").setup({ root_key = "s" })
 
 -- No, that's not a typo, the string has setup in it
 require("rainbow-delimiters.setup").setup({

--- a/optPlugins.nix
+++ b/optPlugins.nix
@@ -3,7 +3,7 @@
 let
   pkgsPlugins = with pkgs.vimPlugins;
   [
-
+    which-key-nvim
   ];
 in
 pkgsPlugins

--- a/other/startPlugins/surround-ui.nix
+++ b/other/startPlugins/surround-ui.nix
@@ -1,0 +1,13 @@
+{ vimUtils, fetchFromGitHub }:
+
+vimUtils.buildVimPlugin {
+  pname = "surround-ui-nvim";
+  version = "FORK";
+
+  src = fetchFromGitHub {
+    owner = "llakala";
+    repo = "surround-ui.nvim";
+    rev = "b88b2c8fdf9f5add01d14302f2e9833983a6bff6";
+    hash = "sha256-3HRx4zQwyiKqJ0phtCvf6ZnoZ2c7XBEMe+y1hWPbpOM=";
+  };
+}


### PR DESCRIPTION
We use my fork of `surround-ui.nvim`, so `nvim-surround` doesn't break `which-key`.