### PR TITLE
flake: move package definition outside of the flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,61 @@
+{ pkgs, mnw }:
+
+let
+  inherit (pkgs) lib;
+
+  mkPackageSet = filepaths: let
+    callPackage = lib.callPackageWith (pkgs // { localPackages = packages; });
+    packages = builtins.mapAttrs
+      (_: path: callPackage path {})
+      filepaths;
+  in packages;
+
+  startPlugins = import ./startPlugins.nix { inherit pkgs; };
+  optPlugins = import ./optPlugins.nix { inherit pkgs; };
+  binaries = import ./binaries.nix { inherit pkgs; };
+
+  customStartPlugins = mkPackageSet {
+    vim-nix = ./other/startPlugins/vim-nix.nix;
+    fFtT-highlights-nvim = ./other/startPlugins/fFtT-highlights-nvim.nix;
+    lazydev-nvim = ./other/startPlugins/lazydev-nvim.nix;
+  };
+  customOptPlugins = {};
+  customBinaries = {};
+
+in mnw.lib.wrap pkgs {
+  appName = "nvim";
+  neovim = pkgs.neovim-unwrapped;
+
+  initLua = /* lua */ ''
+    -- Uncomment when you want to profile nvim startup. Be sure to have
+    -- the snacks.nvim repo cloned for this to work!
+
+    -- vim.opt.rtp:append("/home/emanresu/Documents/repos/snacks.nvim/")
+    -- require("snacks.profiler").startup()
+
+    require("config")
+    require("lz.n").load("lazy")
+
+    -- Add to this whenever you add a new server to the `lsp` folder!
+    -- Ridiculous that nvim can't load them for you as far as I can tell
+    vim.lsp.enable({ "fish_lsp", "gleam", "lua_ls", "nixd",
+    "basedpyright", "ts_ls", "marksman", "tinymist", "clangd" })
+  '';
+
+  plugins.start =
+    startPlugins
+    ++ builtins.attrValues customStartPlugins;
+
+  plugins.opt =
+    optPlugins
+    ++ builtins.attrValues customOptPlugins;
+
+  extraBinPath =
+    binaries
+    ++ builtins.attrValues customBinaries;
+
+  plugins.dev.config = {
+    pure = ./nvim;
+    impure = "/home/emanresu/Documents/projects/meovim/nvim"; # Absolute path needed
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,90 +13,9 @@
       supportedSystems
       (system: function nixpkgs.legacyPackages.${system});
 
-    # Simple callPackage wrapper for easy self-reference
-    mkPackageSet = { pkgs, extras ? {}, filepaths }: let
-      callPackage = lib.callPackageWith (pkgs // extras // { localPackages = packages; });
-      packages = builtins.mapAttrs
-        (_: path: callPackage path {})
-        filepaths;
-    in packages;
-
   in {
-    # When I need something and it isn't packaged already somewhere, I package it
-    # myself. I have these accessible as flake inputs, so I can test them in the
-    # REPL.
-    #
-    # Note that these are disabled when I don't have anything custom right now!
-    neovimStartPlugins = forAllSystems (pkgs: mkPackageSet {
-      inherit pkgs;
-      filepaths = {
-        vim-nix = ./other/startPlugins/vim-nix.nix;
-        fFtT-highlights-nvim = ./other/startPlugins/fFtT-highlights-nvim.nix;
-        lazydev-nvim = ./other/startPlugins/lazydev-nvim.nix;
-      };
-    });
-
-    neovimOptPlugins = forAllSystems (pkgs: mkPackageSet {
-      inherit pkgs;
-      filepaths = {};
-    });
-
-    neovimBinaries = forAllSystems (pkgs: mkPackageSet {
-      inherit pkgs;
-      filepaths = {};
-    });
-
-
-    packages = forAllSystems (pkgs: let
-      # Binaries and plugins that I grab from elsewhere. Stored in their own
-      # files so I'm not editing monolithic files to add stuff
-      startPlugins = import ./startPlugins.nix { inherit pkgs; };
-      optPlugins = import ./optPlugins.nix { inherit pkgs; };
-      binaries = import ./binaries.nix { inherit pkgs; };
-
-      # Custom derivations that I wrote myself. Need to be turned into a list,
-      # since flake inputs are expected to be attrsets.
-      customStartPlugins = builtins.attrValues self.neovimStartPlugins.${pkgs.system};
-      customOptPlugins = builtins.attrValues self.neovimOptPlugins.${pkgs.system};
-      customPackages = builtins.attrValues self.neovimBinaries.${pkgs.system};
-    in {
-      default = inputs.mnw.lib.wrap pkgs {
-        appName = "nvim";
-        neovim = pkgs.neovim-unwrapped;
-
-        initLua = /* lua */ ''
-          -- Uncomment when you want to profile nvim startup. Be sure to have
-          -- the snacks.nvim repo cloned for this to work!
-
-          -- vim.opt.rtp:append("/home/emanresu/Documents/repos/snacks.nvim/")
-          -- require("snacks.profiler").startup()
-
-          require("config")
-          require("lz.n").load("lazy")
-
-          -- Add to this whenever you add a new server to the `lsp` folder!
-          -- Ridiculous that nvim can't load them for you as far as I can tell
-          vim.lsp.enable({ "fish_lsp", "gleam", "lua_ls", "nixd",
-          "basedpyright", "ts_ls", "marksman", "tinymist", "clangd" })
-        '';
-
-        plugins.start =
-          startPlugins
-          ++ customStartPlugins;
-
-        plugins.opt =
-          optPlugins
-          ++ customOptPlugins;
-
-        extraBinPath =
-          binaries ++
-          customPackages;
-
-        plugins.dev.config = {
-          pure = ./nvim;
-          impure = "/home/emanresu/Documents/projects/meovim/nvim"; # Absolute path needed
-        };
-      };
+    packages = forAllSystems (pkgs: {
+      default = import ./default.nix { inherit pkgs; inherit (inputs) mnw; };
     });
 
     devShells = forAllSystems (pkgs: {


### PR DESCRIPTION
Makes it easier for a consumer of the project to go non-flake (which I've done).